### PR TITLE
Fix: useImageDownloader hook

### DIFF
--- a/src/hooks/useImageDownloader.ts
+++ b/src/hooks/useImageDownloader.ts
@@ -6,7 +6,7 @@ interface DownloadImagesProps {
   images: string | string[];
 }
 const downloadSingleImage = (url: string) => {
-  const fileName = url.substring(url.lastIndexOf('/') + 1);
+  const fileName = 'unwrapped-image.png';
   fetch(url)
     .then((response) => response.blob())
     .then((blob) => saveAs(blob, fileName))
@@ -16,7 +16,7 @@ const downloadSingleImage = (url: string) => {
 const downloadMultipleImages = (urls: string[]) => {
   const zip = new JSZip();
   const promises = urls.map((url, index) => {
-    const fileName = `image${index + 1}.jpg`;
+    const fileName = `image${index + 1}.png`;
 
     return fetch(url)
       .then((response) => response.blob())


### PR DESCRIPTION
This pull request fixes the useImageDownloader hook by updating the file names for downloaded images. Previously, the file names were based on the URLs, but now they are set to a specific name. This change ensures that the downloaded images have consistent file names.
