### PR TITLE
Fix: zapier integration mapping

### DIFF
--- a/src/pages/api/followup-user-email.ts
+++ b/src/pages/api/followup-user-email.ts
@@ -65,7 +65,11 @@ export async function sendToZapier(
 ): Promise<ZapierResponse> {
   const zapierWebhookUrl = process.env.ZAPIER_WEBHOOK_URL;
   return axios
-    .post(zapierWebhookUrl, payload)
+    .post(zapierWebhookUrl, {
+      ...payload,
+      gh_login: payload.username,
+      name: payload.fullName
+    })
     .then(handleThen)
     .catch(handleCatch);
 }


### PR DESCRIPTION
This pull request fixes the Zapier integration mapping by adding the `gh_login` and `name` fields to the payload sent to the Zapier webhook. This ensures that the username and full name are included in the payload when making the request to Zapier.