### PR TITLE
Capture failed error in Sentry

### DIFF
--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,5 +1,5 @@
-import * as Sentry from '@sentry/nextjs';
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { logException } from '@/utils/logger';
 
 export const internal = axios.create({
   baseURL: process.env.INTERNAL_API_BASE_URL
@@ -22,9 +22,9 @@ export const handleRequest = <T = any>(
 
 export const handleThen = (r: AxiosResponse) => r.data;
 
-export const handleCatch = (err: { response: AxiosResponse }) => {
+export const handleCatch = (err: AxiosError) => {
   if (process.env.NODE_ENV === 'production') {
-    Sentry.captureException(err);
+    logException(err);
   }
   throw err.response;
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,62 @@
+import { captureException } from '@sentry/nextjs';
+import { toString } from 'ramda';
+
+type CaptureCtx = Parameters<typeof captureException>[1];
+
+type CaptureExc = ReturnType<typeof captureException>;
+
+export function logException(exc: string, message?: string): CaptureExc;
+
+export function logException(exc: Error, message?: string): CaptureExc;
+
+export function logException(exc: string, context?: CaptureCtx): CaptureExc;
+
+export function logException(exc: Error, context?: CaptureCtx): CaptureExc;
+
+export function logException(
+  exc: string | Error,
+  msgOrCtx?: string | CaptureCtx,
+  ctx?: CaptureCtx
+): CaptureExc {
+  const message = typeof msgOrCtx === 'string' ? msgOrCtx : undefined;
+  const context = typeof msgOrCtx === 'object' ? msgOrCtx : ctx;
+  const name = (() => {
+    try {
+      return typeof exc === 'string'
+        ? exc
+        : exc instanceof Error
+          ? exc.message
+          : toString(exc);
+    } catch (e) {
+      return 'Something went wrong (even while trying to process the error)';
+    }
+  })();
+  const stack = (() => {
+    try {
+      return exc instanceof Error ? exc.stack : undefined;
+    } catch (e) {
+      return 'Something went wrong (even while trying to process the error)';
+    }
+  })();
+
+  const err = new Error(message || name);
+  err.name = name;
+  if (stack) err.stack = stack;
+
+  return captureException(err, {
+    ...context,
+    extra: {
+      // @ts-ignore because sentry wasn't exporting the correct types to make this possible otherwise
+      ...context?.extra,
+      internal_original_exception: exc,
+      ...(exc instanceof Error
+        ? {
+            internal_original_exception_name: exc.name,
+            internal_original_exception_message: exc.message,
+            internal_original_exception_stack: exc.stack,
+            stack
+          }
+        : {})
+    }
+  });
+}


### PR DESCRIPTION
This pull request adds error capturing functionality using Sentry to the handleCatch function. This allows for better error tracking and debugging in production environments.