### PR TITLE
Add toast notifications for image downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-icons": "^4.12.0",
     "react-responsive-masonry": "^2.1.7",
     "react-simple-typewriter": "^5.0.1",
+    "react-tooltip": "^5.25.0",
     "swiper": "^11.0.5",
     "ts-node": "^10.9.2",
     "usehooks-ts": "^2.9.1",

--- a/src/hooks/useImageDownloaderAsPdfHook.ts
+++ b/src/hooks/useImageDownloaderAsPdfHook.ts
@@ -1,6 +1,7 @@
 import jsPDF from 'jspdf';
 import { rgbToHex, darkenHexColor } from '@/api-helpers/general';
 import { UpdatedImageFile } from '@/types/images';
+import toast from 'react-hot-toast';
 
 interface DownloadImagesAsPdfProps {
   images: UpdatedImageFile[];
@@ -62,7 +63,21 @@ const downloadImagesAsPdf = async ({ images }: DownloadImagesAsPdfProps) => {
 };
 
 export const useImageDownloaderAsPdf = () => {
-  return downloadImagesAsPdf;
+  return ({ images }: DownloadImagesAsPdfProps) =>
+    toast.promise(
+      downloadImagesAsPdf({ images }),
+      {
+        loading: 'Processing PDF',
+        success: 'Downloaded',
+        error: 'Error while processing'
+      },
+      {
+        position: 'top-right',
+        success: {
+          duration: 3000
+        }
+      }
+    );
 };
 
 async function getColorFromImage(imageUrl: string): Promise<string> {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,7 +4,6 @@ import { SessionProvider } from 'next-auth/react';
 import { AppStateProvider } from '@/contexts/AppContext';
 import { AppLoadingStateWrapper } from '@/components/AppLoadingStateWrapper';
 import { Toaster } from 'react-hot-toast';
-import '@/styles/swiper.css';
 import { inter } from '@/styles/fonts';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -13,6 +12,8 @@ import { useEffect } from 'react';
 import { track, ALLOW_TRACKING_KEY } from '@/constants/events';
 import { useLocalStorage } from 'usehooks-ts';
 import Script from 'next/script';
+import '@/styles/swiper.css';
+import 'react-tooltip/dist/react-tooltip.css';
 
 export default function App({
   Component,

--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -13,6 +13,7 @@ import toast from 'react-hot-toast';
 import { UpdatedImageFile } from '@/types/images';
 import { track } from '@/constants/events';
 import { GithubUser } from '@/api-helpers/exapi-sdk/types';
+import { Tooltip } from 'react-tooltip';
 
 const LINKEDIN_URL = 'https://www.linkedin.com/';
 
@@ -73,6 +74,7 @@ export default function StatsUnwrapped() {
             images={images}
             singleImageSharingCallback={downloadImage}
           />
+
           <div className="flex gap-4  p-3 rounded-lg bg-indigo-900 bg-opacity-60 cursor-pointer">
             <FaDownload
               size={36}
@@ -80,6 +82,8 @@ export default function StatsUnwrapped() {
                 downloadImage({ images });
                 track('ZIP_DOWNLOAD_CLICKED');
               }}
+              data-tooltip-id="carousel-action-menu"
+              data-tooltip-content="Download as zip"
             />
             <Link href={LINKEDIN_URL} target="_blank">
               <FaLinkedin
@@ -88,6 +92,8 @@ export default function StatsUnwrapped() {
                   downloadImagesAsPdf({ images });
                   track('LINKEDIN_SHARE_CLICKED');
                 }}
+                data-tooltip-id="carousel-action-menu"
+                data-tooltip-content="Share on LinkedIn"
               />
             </Link>
 
@@ -97,8 +103,11 @@ export default function StatsUnwrapped() {
                 downloadImagesAsPdf({ images });
                 track('PDF_DOWNLOAD_CLICKED');
               }}
+              data-tooltip-id="carousel-action-menu"
+              data-tooltip-content="Download as PDF"
             />
           </div>
+          <Tooltip id="carousel-action-menu" />
         </div>
       )}
     </div>

--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -89,7 +89,6 @@ export default function StatsUnwrapped() {
               <FaLinkedin
                 size={36}
                 onClick={() => {
-                  downloadImagesAsPdf({ images });
                   track('LINKEDIN_SHARE_CLICKED');
                 }}
                 data-tooltip-id="carousel-action-menu"
@@ -99,7 +98,7 @@ export default function StatsUnwrapped() {
 
             <FaFilePdf
               size={36}
-              onClick={() => {
+              onClick={async () => {
                 downloadImagesAsPdf({ images });
                 track('PDF_DOWNLOAD_CLICKED');
               }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,26 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz"
   integrity sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==
 
+"@floating-ui/core@^1.4.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.2.tgz#53a0f7a98c550e63134d504f26804f6b83dbc071"
+  integrity sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
+  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -5264,6 +5284,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-css@^4.2.3:
   version "4.2.4"
@@ -13479,6 +13504,14 @@ react-simple-typewriter@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-simple-typewriter/-/react-simple-typewriter-5.0.1.tgz#cfdb896c868a55ed4d5f1f06d62b3a9d0f5ad9d7"
   integrity sha512-vA5HkABwJKL/DJ4RshSlY/igdr+FiVY4MLsSQYJX6FZG/f1/VwN4y1i3mPXRyfaswrvI8xii1kOVe1dYtO2Row==
+
+react-tooltip@^5.25.0:
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.25.0.tgz#09d259c041bca1908449ac27b39717162655e0e3"
+  integrity sha512-/eGhmlwbHlJrVoUe75fb58rJfAy9aZnTvQAK9ZUPM0n9mmBGpEk13vDPiQVCeUuax+fBej+7JPsUXlhzaySc7w==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+    classnames "^2.3.0"
 
 react@^18:
   version "18.2.0"


### PR DESCRIPTION
This pull request adds toast notifications for image downloads in the useImageDownloader and useImageDownloaderAsPdf hooks. The toast notifications provide feedback to the user during the image processing and downloading process.
This pull request also add react-tooltip to add informative tooltips on carousel action menu



https://github.com/middlewarehq/unwrapped/assets/60030881/efeaf831-78dd-49df-af7d-f07916daff2c


