### PR TITLE
Fix hashing and update image URLs

### DIFF
--- a/src/components/SwiperCarousel.tsx
+++ b/src/components/SwiperCarousel.tsx
@@ -24,7 +24,6 @@ interface SwiperCarouselProps {
   }: {
     images: UpdatedImageFile;
   }) => void;
-  useLinksToRenderImages?: boolean;
   hideShareButtons?: boolean;
 }
 
@@ -32,7 +31,6 @@ const SwiperCarousel: React.FC<SwiperCarouselProps> = ({
   singleImageSharingCallback,
   userName,
   images,
-  useLinksToRenderImages = false,
   hideShareButtons = false
 }) => {
   const sliderRef = useRef<SwiperRef | null>(null);
@@ -113,10 +111,7 @@ const SwiperCarousel: React.FC<SwiperCarouselProps> = ({
                 onClick={handlePrev}
               />
             )}
-            <img
-              src={useLinksToRenderImages ? image.url : image.data}
-              alt={`Slide ${index + 1}`}
-            />
+            <img src={image.data} alt={`Slide ${index + 1}`} />
 
             <IoIosArrowDroprightCircle
               size={36}

--- a/src/pages/api/get-all-images/index.ts
+++ b/src/pages/api/get-all-images/index.ts
@@ -27,7 +27,8 @@ const checkHash = async (req: NextApiRequest, res: NextApiResponse) => {
         const hash = bcryptGen((username as string) + filename);
         return {
           ...image,
-          url: `/shared/${username}/${filename}/${hash}`
+          url: `/shared/${username}/${filename}/${hash}`,
+          data: `data:image/png;base64,${image.data.toString('base64')}`
         };
       });
 

--- a/src/pages/api/get-all-images/index.ts
+++ b/src/pages/api/get-all-images/index.ts
@@ -17,7 +17,7 @@ const checkHash = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const userNameHash = bcryptGen(username as string);
-  const isValid = userNameHash === hash;
+  const isValid = userNameHash === (hash as string);
 
   if (isValid) {
     try {

--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -72,7 +72,6 @@ export default function StatsUnwrapped() {
       {images?.length && (
         <div className="flex flex-col items-center gap-4 w-full ">
           <SwiperCarousel
-            useLinksToRenderImages
             userName={userName}
             images={images}
             singleImageSharingCallback={downloadImage}

--- a/src/pages/view/[username]/[...hash].tsx
+++ b/src/pages/view/[username]/[...hash].tsx
@@ -25,7 +25,7 @@ export default function StatsUnwrapped() {
     handleRequest<{
       isValid: boolean;
       data: UpdatedImageFile[];
-    }>('/api/getAllImages', {
+    }>('/api/get-all-images', {
       method: 'GET',
       params: {
         hash: hash,

--- a/src/pages/view/[username]/[...hash].tsx
+++ b/src/pages/view/[username]/[...hash].tsx
@@ -35,10 +35,10 @@ export default function StatsUnwrapped() {
       .then((res) => {
         setIsUrlValid(res.isValid);
         if (res.isValid) {
-          const imageData: UpdatedImageFile[] = res.data.map((link) => ({
-            url: `${window.location.origin}${link.url}`,
-            fileName: link.fileName,
-            data: link.data
+          const imageData: UpdatedImageFile[] = res.data.map((image) => ({
+            url: `${window.location.origin}${image.url}`,
+            fileName: image.fileName,
+            data: image.data
           }));
           setImages(imageData);
         }
@@ -73,7 +73,6 @@ export default function StatsUnwrapped() {
       {images?.length && (
         <div className="flex flex-col items-center gap-4 w-full ">
           <SwiperCarousel
-            useLinksToRenderImages
             hideShareButtons
             userName={userName}
             images={images}

--- a/src/utils/stringHelpers.ts
+++ b/src/utils/stringHelpers.ts
@@ -10,7 +10,7 @@ export const bcryptGen = (username: string): string => {
   const salt = process.env.HASHING_SALT as string;
   if (!salt) return '';
   const hash = hashSync(username, salt);
-  return hash.slice(-HASH_LENGTH);
+  return btoa(hash.slice(-HASH_LENGTH));
 };
 
 export const extractFilenameWithoutExtension = (input: string): string => {


### PR DESCRIPTION
This pull request fixes the hashing issue and updates the image URLs in the SwiperCarousel component. The useLinksToRenderImages prop has been removed and the image URLs are now generated using base64 encoding.