### PR TITLE
Fix next and prev arrow btn logic

### DIFF
--- a/src/components/SwiperCarousel.tsx
+++ b/src/components/SwiperCarousel.tsx
@@ -120,16 +120,22 @@ const SwiperCarousel: React.FC<SwiperCarouselProps> = ({
               />
             )}
             <img src={image.data} alt={`Slide ${index + 1}`} />
-
-            <IoIosArrowDroprightCircle
-              size={36}
-              className="next-arrow left-[90%] sm:left-[102%]"
-              onClick={handleNext}
-            />
+            {(index !== images.length - 1 || !hideEmailInput) && (
+              <IoIosArrowDroprightCircle
+                size={36}
+                className="next-arrow left-[90%] sm:left-[102%]"
+                onClick={handleNext}
+              />
+            )}
           </SwiperSlide>
         ))}
         {!hideEmailInput && (
           <SwiperSlide className="swiper-slide-img email-input-card flex flex-col w-full h-full bg-no-repeat bg-cover bg-center bg-fixed">
+            <IoIosArrowDropleftCircle
+              size={36}
+              className="prev-arrow right-[90%] sm:right-[102%]"
+              onClick={handlePrev}
+            />
             <UserEmailInputCard />
           </SwiperSlide>
         )}


### PR DESCRIPTION
This pull request fixes the logic for the next and previous arrow buttons in the SwiperCarousel component. Previously, the next arrow button was always displayed, even on the last slide, and the previous arrow button was not displayed on the first slide. This PR updates the logic to only display the next arrow button if it is not the last slide, and to display the previous arrow button if it is not the first slide.