### PR TITLE
Add usePrebuiltToasts hook and customize Toaster component

### DIFF
--- a/src/hooks/usePrebuiltToasts.ts
+++ b/src/hooks/usePrebuiltToasts.ts
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+export const usePrebuiltToasts = () => {
+  const InvalidEmailToast = useCallback(
+    () =>
+      toast.error('Invalid email address', {
+        id: 'invalid-email'
+      }),
+    []
+  );
+  const emailIsRequiredToast = useCallback(
+    () =>
+      toast.error('Email is required', {
+        id: 'email-is-required'
+      }),
+    []
+  );
+  const noImagesToast = useCallback(
+    () =>
+      toast.error('No images found', {
+        duration: 10000,
+        icon: '🤔',
+        id: 'no-images-found'
+      }),
+    []
+  );
+  const invalidUrlToast = useCallback(
+    () =>
+      toast.error('Invalid URL', {
+        duration: 10000,
+        icon: '😢',
+        id: 'invalid-url'
+      }),
+    []
+  );
+
+  return {
+    InvalidEmailToast,
+    emailIsRequiredToast,
+    noImagesToast,
+    invalidUrlToast
+  };
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -105,7 +105,12 @@ export default function App({
         <SessionProvider session={session}>
           <AppStateProvider>
             <AppLoadingStateWrapper>
-              <Toaster />
+              <Toaster
+                position="top-right"
+                toastOptions={{
+                  style: { background: '#363636', color: '#fff' }
+                }}
+              />
               <Component {...pageProps} />
             </AppLoadingStateWrapper>
           </AppStateProvider>

--- a/src/pages/view/[username]/[...hash].tsx
+++ b/src/pages/view/[username]/[...hash].tsx
@@ -5,23 +5,23 @@ import { LoaderWithFacts } from '@/components/LoaderWithFacts';
 import SwiperCarousel from '@/components/SwiperCarousel';
 import { useImageDownloader } from '@/hooks/useImageDownloader';
 import Confetti from 'react-confetti';
-import toast from 'react-hot-toast';
 import { UpdatedImageFile } from '@/types/images';
 import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import { track } from '@/constants/events';
+import { usePrebuiltToasts } from '@/hooks/usePrebuiltToasts';
 
 export default function StatsUnwrapped() {
-  const [isLoading, setIsLoading] = useState(false);
-  const downloadImage = useImageDownloader();
-
   const router = useRouter();
-  const userName = router.query.username as string;
-  const hash = (router.query.hash as string[])?.join('/');
-
+  const downloadImage = useImageDownloader();
+  const { noImagesToast, invalidUrlToast } = usePrebuiltToasts();
+  const [isLoading, setIsLoading] = useState(false);
   const [isUrlValid, setIsUrlValid] = useState(false);
   const [images, setImages] = useState<UpdatedImageFile[] | null>(null);
+
+  const userName = router.query.username as string;
+  const hash = (router.query.hash as string[])?.join('/');
 
   useEffect(() => {
     if (!userName || !hash || isUrlValid) return;
@@ -44,18 +44,21 @@ export default function StatsUnwrapped() {
             fileName: image.fileName,
             data: image.data
           }));
+          if (!imageData.length) {
+            router.replace('/');
+            return noImagesToast();
+          }
           setImages(imageData);
         }
       })
       .catch((_) => {
-        toast.error('Invalid URL', {
-          position: 'top-right'
-        });
+        router.replace('/');
+        invalidUrlToast();
       })
       .finally(() => {
         setIsLoading(false);
       });
-  }, [userName, hash, isUrlValid]);
+  }, [userName, hash, isUrlValid, router, noImagesToast, invalidUrlToast]);
 
   const Header = () => (
     <>


### PR DESCRIPTION
This pull request adds a new hook called usePrebuiltToasts and customizes the Toaster component. The usePrebuiltToasts hook provides prebuilt toast functions for displaying error messages, such as InvalidEmailToast, emailIsRequiredToast, noImagesToast, and invalidUrlToast. The Toaster component is also customized with a new position and toast options.