### PR TITLE
Refactor toast messages and add usePrebuiltToasts hook

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -139,14 +139,10 @@ export const copyToClipboard = async (
 ) => {
   try {
     await navigator.clipboard.writeText(textToCopy);
-    toast.success('Copied to clipboard', {
-      position: 'top-right'
-    });
+    toast.success('Copied to clipboard');
     onCopy && onCopy(textToCopy);
   } catch (err) {
-    toast.error('Error copying to clipboard', {
-      position: 'top-right'
-    });
+    toast.error('Error copying to clipboard');
     logException(`Error copying to clipboard: ${textToCopy}`, {
       originalException: err
     });

--- a/src/components/UserEmailInputCard.tsx
+++ b/src/components/UserEmailInputCard.tsx
@@ -36,9 +36,7 @@ export const UserEmailInputCard = () => {
   const markUserEmailAsInvalid = useCallback(
     (isInvalidEmailType: InvalidEmailEnum) => {
       setIsInvalidEmail(isInvalidEmailType);
-      return toast.error(InvalidEmailMessage[isInvalidEmailType], {
-        position: 'top-right'
-      });
+      return toast.error(InvalidEmailMessage[isInvalidEmailType]);
     },
     []
   );
@@ -60,9 +58,7 @@ export const UserEmailInputCard = () => {
     })
       .then(() => {
         setIsEmailSubmitted(true);
-        toast.success('Success', {
-          position: 'top-right'
-        });
+        toast.success('Success');
       })
       .catch(() => setIsEmailSubmitted(false));
   }, [markUserEmailAsInvalid, saveUsernameAndFullName, userEmail]);

--- a/src/hooks/useImageDownloader.ts
+++ b/src/hooks/useImageDownloader.ts
@@ -54,9 +54,8 @@ export const useImageDownloader = () => {
         error: 'Error while processing'
       },
       {
-        position: 'top-right',
         success: {
-          duration: 3000
+          duration: 5000
         }
       }
     );

--- a/src/hooks/usePrebuiltToasts.ts
+++ b/src/hooks/usePrebuiltToasts.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+
+export const usePrebuiltToasts = () => {
+  const InvalidEmailToast = useCallback(
+    () =>
+      toast.error('Invalid email address', {
+        id: 'invalid-email'
+      }),
+    []
+  );
+  const emailIsRequiredToast = useCallback(
+    () =>
+      toast.error('Email is required', {
+        id: 'email-is-required'
+      }),
+    []
+  );
+  const noImagesToast = useCallback(
+    () =>
+      toast.error('No images found', {
+        duration: 6000,
+        icon: '🤔',
+        id: 'no-images-found'
+      }),
+    []
+  );
+  const invalidUrlToast = useCallback(
+    () =>
+      toast.error('Invalid URL', {
+        duration: 6000,
+        icon: '😢',
+        id: 'invalid-url'
+      }),
+    []
+  );
+  const unauthenticatedToast = useCallback(
+    () =>
+      toast.error(
+        "Seems like you aren't authenticated. Taking you back home.",
+        {
+          id: 'unauthenticated'
+        }
+      ),
+    []
+  );
+
+  const somethingWentWrongToast = useCallback(
+    () =>
+      toast.error('Something went wrong. Please try again.', {
+        id: 'something-went-wrong'
+      }),
+    []
+  );
+
+  return {
+    InvalidEmailToast,
+    emailIsRequiredToast,
+    noImagesToast,
+    invalidUrlToast,
+    unauthenticatedToast,
+    somethingWentWrongToast
+  };
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -105,7 +105,12 @@ export default function App({
         <SessionProvider session={session}>
           <AppStateProvider>
             <AppLoadingStateWrapper>
-              <Toaster />
+              <Toaster
+                position="top-right"
+                toastOptions={{
+                  style: { background: '#363636', color: '#fff' }
+                }}
+              />
               <Component {...pageProps} />
             </AppLoadingStateWrapper>
           </AppStateProvider>

--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -9,7 +9,6 @@ import { useImageDownloader } from '@/hooks/useImageDownloader';
 import { useImageDownloaderAsPdf } from '@/hooks/useImageDownloaderAsPdfHook';
 import Confetti from 'react-confetti';
 import Link from 'next/link';
-import toast from 'react-hot-toast';
 import { ImageAPIResponse, UpdatedImageFile } from '@/types/images';
 import { track } from '@/constants/events';
 import { GithubUser } from '@/api-helpers/exapi-sdk/types';
@@ -17,10 +16,12 @@ import { copyToClipboard } from '@/components/ShareButton';
 import { Tooltip } from 'react-tooltip';
 import { AxiosError } from 'axios';
 import { signOut } from 'next-auth/react';
+import { usePrebuiltToasts } from '@/hooks/usePrebuiltToasts';
 
 const LINKEDIN_URL = 'https://www.linkedin.com/';
 
 export default function StatsUnwrapped() {
+  const { somethingWentWrongToast, unauthenticatedToast } = usePrebuiltToasts();
   const [isLoading, setIsLoading] = useState(false);
   const downloadImage = useImageDownloader();
   const downloadImagesAsPdf = useImageDownloaderAsPdf();
@@ -40,13 +41,10 @@ export default function StatsUnwrapped() {
       handledErrStatus = err.status;
 
       if (err.status === 403) {
-        toast.error(
-          "Seems like you aren't authenticated. Taking you back home.",
-          { position: 'top-right' }
-        );
+        unauthenticatedToast();
         return signOut({ redirect: false });
       }
-      toast.error('Something went wrong', { position: 'top-right' });
+      somethingWentWrongToast();
     };
 
     Promise.all([
@@ -62,7 +60,7 @@ export default function StatsUnwrapped() {
         })
         .catch(handleErr)
     ]).finally(() => setIsLoading(false));
-  }, [setUnwrappedImages]);
+  }, [setUnwrappedImages, somethingWentWrongToast, unauthenticatedToast]);
 
   if (isLoading) {
     return (

--- a/src/pages/view/[username]/[...hash].tsx
+++ b/src/pages/view/[username]/[...hash].tsx
@@ -5,18 +5,19 @@ import { LoaderWithFacts } from '@/components/LoaderWithFacts';
 import SwiperCarousel from '@/components/SwiperCarousel';
 import { useImageDownloader } from '@/hooks/useImageDownloader';
 import Confetti from 'react-confetti';
-import toast from 'react-hot-toast';
 import { UpdatedImageFile } from '@/types/images';
 import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import { track } from '@/constants/events';
+import { usePrebuiltToasts } from '@/hooks/usePrebuiltToasts';
 
 export default function StatsUnwrapped() {
+  const router = useRouter();
+  const { noImagesToast, invalidUrlToast } = usePrebuiltToasts();
   const [isLoading, setIsLoading] = useState(false);
   const downloadImage = useImageDownloader();
 
-  const router = useRouter();
   const userName = router.query.username as string;
   const hash = (router.query.hash as string[])?.join('/');
 
@@ -44,18 +45,21 @@ export default function StatsUnwrapped() {
             fileName: image.fileName,
             data: image.data
           }));
+          if (!imageData.length) {
+            router.replace('/');
+            return noImagesToast();
+          }
           setImages(imageData);
         }
       })
       .catch((_) => {
-        toast.error('Invalid URL', {
-          position: 'top-right'
-        });
+        router.replace('/');
+        return invalidUrlToast();
       })
       .finally(() => {
         setIsLoading(false);
       });
-  }, [userName, hash, isUrlValid]);
+  }, [userName, hash, isUrlValid, router, noImagesToast, invalidUrlToast]);
 
   const Header = () => (
     <>


### PR DESCRIPTION
This PR refactors the toast messages in the code to remove unnecessary options and adds a new hook called usePrebuiltToasts for displaying prebuilt toast messages.


https://github.com/middlewarehq/unwrapped/assets/60030881/bbae2eba-a874-4a7c-87dc-d138c15dfa45

