### PR TITLE
Functionality to add most Productive Time of day

### DIFF
--- a/src/analytics/__tests__/pr-analytics.tests.ts
+++ b/src/analytics/__tests__/pr-analytics.tests.ts
@@ -13,7 +13,8 @@ import {
   getPRFirstResponseTimeInSeconds,
   getSumOfFirstResponseTimes,
   getReworkTimeInSeconds,
-  getSumOfReworkTimes
+  getSumOfReworkTimes,
+  getMostProductiveHour
 } from '../pr-analytics';
 import { getPullRequest, getReview } from '../test-utils/factories';
 
@@ -1332,4 +1333,98 @@ test('getSumOfReworkTimes does not account prs with negative rework.', () => {
     parseISO(review0.createdAt)
   );
   expect(getSumOfReworkTimes([pr1, pr2, pr3])).toStrictEqual(a);
+});
+
+test('getMostProductiveHour return -1 for no PRs', () => {
+  expect(getMostProductiveHour([], 'UTC')).toStrictEqual(-1);
+});
+
+test('getMostProductiveHour return correct hour for different timezone', () => {
+  const prAuthor = 'samad-yar-khan';
+
+  const pr1 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T12:22:52Z'
+  });
+  const pr2 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T05:22:52Z'
+  });
+  const pr3 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-12T01:22:52Z'
+  });
+  const pr4 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-11T11:22:52Z'
+  });
+  const pr5 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-11T12:22:52Z'
+  });
+  const pr6 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-10T14:22:52Z'
+  });
+  const pr7 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T12:22:52Z'
+  });
+
+  expect(
+    getMostProductiveHour([pr1, pr2, pr3, pr4, pr5, pr6, pr7], 'UTC')
+  ).toStrictEqual(12);
+  expect(
+    getMostProductiveHour([pr1, pr2, pr3, pr4, pr5, pr6, pr7], 'EST')
+  ).toStrictEqual(7);
+  expect(
+    getMostProductiveHour([pr1, pr2, pr3, pr4, pr5, pr6, pr7], 'Asia/Kolkata')
+  ).toStrictEqual(17);
+  expect(
+    getMostProductiveHour([pr1, pr2, pr3, pr4, pr5, pr6, pr7], 'IST')
+  ).toStrictEqual(17);
+});
+
+test('getMostProductiveHour return earliest hour for equal distribution of PRs across day', () => {
+  const prAuthor = 'samad-yar-khan';
+
+  const pr1 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T12:22:52Z'
+  });
+  const pr2 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T13:22:52Z'
+  });
+  const pr3 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-12T14:22:52Z'
+  });
+  const pr4 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-11T15:22:52Z'
+  });
+  const pr5 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-11T16:22:52Z'
+  });
+  const pr6 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-10T17:22:52Z'
+  });
+  const pr7 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T18:22:52Z'
+  });
+  const pr8 = getPullRequest({
+    authorLogin: prAuthor,
+    createdAt: '2023-05-09T00:22:52Z'
+  });
+
+  expect(
+    getMostProductiveHour([pr1, pr2, pr3, pr4, pr5, pr6, pr7], 'UTC')
+  ).toStrictEqual(12);
+  expect(
+    getMostProductiveHour([pr1, pr2, pr3, pr4, pr5, pr6, pr7, pr8], 'UTC')
+  ).toStrictEqual(0);
 });

--- a/src/analytics/pr-analytics.ts
+++ b/src/analytics/pr-analytics.ts
@@ -232,3 +232,22 @@ export const getReworkTimeInSeconds = (pr: PullRequest) => {
 export const getSumOfReworkTimes = (prs: PullRequest[]) => {
   return sum(prs.map((pr) => Math.max(0, getReworkTimeInSeconds(pr))));
 };
+
+export const getMostProductiveHour = (
+  prs: PullRequest[],
+  timeZone: string
+): number => {
+  if (!prs?.length) return -1;
+
+  let hourWisePrFrequencyBucket = new Array(24).fill(0);
+
+  for (let pr of prs) {
+    const createdAt = new Date(pr.createdAt);
+    const localTime = new Date(createdAt.toLocaleString('en-US', { timeZone }));
+    const hour = localTime.getHours();
+    hourWisePrFrequencyBucket[hour] += 1;
+  }
+  return hourWisePrFrequencyBucket.indexOf(
+    Math.max(...hourWisePrFrequencyBucket)
+  );
+};

--- a/src/api-helpers/unrwrapped-aggregator.ts
+++ b/src/api-helpers/unrwrapped-aggregator.ts
@@ -6,6 +6,7 @@ import {
 } from '@/analytics/contribution-analytics';
 import {
   getCommitPercentile,
+  getMostProductiveHour,
   getPRListAndMonthlyCountsFromGqlResponse,
   getSumOfFirstResponseTimes,
   getSumOfReworkTimes,
@@ -99,6 +100,11 @@ export const fetchGithubUnwrappedData = async (
       user.login
     );
 
+  const hour_with_max_opened_prs = getMostProductiveHour(
+    authored_prs,
+    timezone
+  );
+
   return {
     user,
     authored_monthly_pr_counts,
@@ -125,7 +131,8 @@ export const fetchGithubUnwrappedData = async (
     total_review_contributions:
       contribution_summary?.totalPullRequestReviewContributions,
     total_issue_contributions: contribution_summary?.totalIssueContributions,
-    global_contributions: 4500000000
+    global_contributions: 4500000000,
+    hour_with_max_opened_prs: hour_with_max_opened_prs
   };
 };
 

--- a/src/types/api-responses.ts
+++ b/src/types/api-responses.ts
@@ -68,6 +68,7 @@ export type GitHubDataResponse = {
   total_pr_contributions?: number;
   total_review_contributions?: number;
   total_issue_contributions?: number;
+  hour_with_max_opened_prs?: number;
 };
 
 export type GithubRepositoryContributionData = {


### PR DESCRIPTION
## Issue(s) 

- Resolves #110
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->


## Acceptance Criteria fulfilment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided -->

- [x] Add method to return hour with most opened PRs `getMostProductiveHour`.
- [x] Add tests `getMostProductiveHour`.
- [x] Update GitHubDataResponse to include `hour_with_max_opened_prs`

## Proposed changes (including videos or screenshots)

- Add functionality to add most productive time of day.

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->