### PR TITLE
Update LinkedIn URL in stats-unwrapped.tsx

### DIFF
--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -18,7 +18,7 @@ import { AxiosError } from 'axios';
 import { signOut, useSession } from 'next-auth/react';
 import { usePrebuiltToasts } from '@/hooks/usePrebuiltToasts';
 
-const LINKEDIN_URL = 'https://www.linkedin.com/';
+const LINKEDIN_URL = 'https://www.linkedin.com/sharing/share-offsite/?url=';
 
 export default function StatsUnwrapped() {
   const { status } = useSession();
@@ -106,7 +106,12 @@ export default function StatsUnwrapped() {
               data-tooltip-id="carousel-action-menu"
               data-tooltip-content="Download as zip"
             />
-            <Link href={LINKEDIN_URL} target="_blank">
+            <Link
+              href={`${LINKEDIN_URL}${encodeURIComponent(
+                window.location.origin + shareUrl
+              )}`}
+              target="_blank"
+            >
               <FaLinkedin
                 size={36}
                 onClick={() => {


### PR DESCRIPTION
This pull request updates the LinkedIn URL in the stats-unwrapped.tsx file. The previous URL was pointing to the LinkedIn homepage, but now it is updated to include the share-offsite URL with the current page's origin and share URL. This ensures that when users click on the LinkedIn icon, it will share the correct URL.