### PR TITLE
Update links and styles in index.tsx, stats-unwrapped.tsx, and [...hash].tsx

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -62,6 +62,19 @@ export default function Home() {
           </span>
           <Description />
           <AuthActions />
+          <a
+            href="https://www.producthunt.com/posts/unwrapped-by-middleware?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-unwrapped&#0045;by&#0045;middleware"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <img
+              src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=428918&theme=light"
+              alt="Unwrapped&#0032;by&#0032;Middleware - Your&#0032;Dev&#0032;year&#0032;2023&#0032;unwrapped | Product Hunt"
+              style={{ width: '250px', height: '54px' }}
+              width="250"
+              height="54"
+            />
+          </a>
         </div>
         <div className="flex flex-col mt-8">
           <MouseScrollAnim fontSize="1.4em" />

--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -80,7 +80,7 @@ export default function StatsUnwrapped() {
   };
 
   return (
-    <div className="items-center justify-center p-4 min-h-screen w-full flex flex-col gap-10 text-center">
+    <div className="items-center justify-center p-4 min-h-screen w-full flex flex-col gap-8 text-center">
       <div>
         <h2 className="text-2xl">
           🚀 Let&apos;s unwrap your GitHub journey of 2023! 🎉
@@ -121,6 +121,19 @@ export default function StatsUnwrapped() {
           </div>
         </div>
       )}
+      <a
+        href="https://www.producthunt.com/posts/unwrapped-by-middleware?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-unwrapped&#0045;by&#0045;middleware"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <img
+          src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=428918&theme=light"
+          alt="Unwrapped&#0032;by&#0032;Middleware - Your&#0032;Dev&#0032;year&#0032;2023&#0032;unwrapped | Product Hunt"
+          style={{ width: '250px', height: '54px' }}
+          width="250"
+          height="54"
+        />
+      </a>
     </div>
   );
 }

--- a/src/pages/view/[username]/[...hash].tsx
+++ b/src/pages/view/[username]/[...hash].tsx
@@ -96,7 +96,7 @@ export default function StatsUnwrapped() {
   return (
     <>
       <Header />
-      <div className="items-center justify-center p-4 min-h-screen w-full flex flex-col gap-10 text-center">
+      <div className="items-center justify-center p-4 min-h-screen w-full flex flex-col gap-8 text-center">
         <div>
           <h2 className="text-2xl">
             Unwrap{' '}
@@ -124,6 +124,19 @@ export default function StatsUnwrapped() {
             Wish to create your own? Click here {'->'}
           </span>
         </Link>
+        <a
+          href="https://www.producthunt.com/posts/unwrapped-by-middleware?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-unwrapped&#0045;by&#0045;middleware"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <img
+            src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=428918&theme=light"
+            alt="Unwrapped&#0032;by&#0032;Middleware - Your&#0032;Dev&#0032;year&#0032;2023&#0032;unwrapped | Product Hunt"
+            style={{ width: '250px', height: '54px' }}
+            width="250"
+            height="54"
+          />
+        </a>
       </div>
     </>
   );


### PR DESCRIPTION
This pull request updates the links and styles in the index.tsx, stats-unwrapped.tsx, and [...hash].tsx files. The changes include adding a new link to a Product Hunt post and updating the styles for better visual consistency.
<img width="1512" alt="image" src="https://github.com/middlewarehq/unwrapped/assets/60030881/49ad6214-0d19-45a8-ad76-36f4d047a71e">
<img width="1512" alt="image" src="https://github.com/middlewarehq/unwrapped/assets/60030881/f210dfad-2767-464d-9d66-496c47f98afe">
<img width="1512" alt="image" src="https://github.com/middlewarehq/unwrapped/assets/60030881/fd5dad87-b736-43d7-b32c-8d69fb8242aa">
<img width="1512" alt="image" src="https://github.com/middlewarehq/unwrapped/assets/60030881/f93f1f06-5afd-4679-ac93-42980797a829">
