### PR TITLE
Update isLoading state to true in StatsUnwrapped and [...hash] components

### DIFF
--- a/src/pages/stats-unwrapped.tsx
+++ b/src/pages/stats-unwrapped.tsx
@@ -18,7 +18,7 @@ import { usePrebuiltToasts } from '@/hooks/usePrebuiltToasts';
 export default function StatsUnwrapped() {
   const { status } = useSession();
   const { somethingWentWrongToast, unauthenticatedToast } = usePrebuiltToasts();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const downloadImage = useImageDownloader();
   const [images, setUnwrappedImages] = useState<UpdatedImageFile[] | null>(
     null

--- a/src/pages/view/[username]/[...hash].tsx
+++ b/src/pages/view/[username]/[...hash].tsx
@@ -17,7 +17,7 @@ export default function StatsUnwrapped() {
   const router = useRouter();
   const { status } = useSession();
   const { noImagesToast, invalidUrlToast } = usePrebuiltToasts();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const downloadImage = useImageDownloader();
 
   const userName = router.query.username as string;


### PR DESCRIPTION
This pull request updates the isLoading state to true in the StatsUnwrapped and [...hash] components. This change ensures that the loading state is set correctly when the components are rendered initially.