### PR TITLE
Tooltip Added for all icons in Share Card

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -319,7 +319,7 @@ const ShareMenu2 = ({
             <Tooltip id="go-download" />
             <GoDownload
               data-tooltip-id="go-download"
-              data-tooltip-content="Downlaod Image"
+              data-tooltip-content="Download Image"
               size={18}
             />
           </Button>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -5,6 +5,7 @@ import { GoCopy, GoDownload, GoX } from 'react-icons/go';
 import { track } from '@/constants/events';
 import toast from 'react-hot-toast';
 import { logException } from '@/utils/logger';
+import { Tooltip } from 'react-tooltip';
 
 type ShareButtonProps = {
   imageUrl?: string;
@@ -279,35 +280,59 @@ const ShareMenu2 = ({
             isSelected={optionSelected === ShareOption.COPY}
             onClick={selectCopy}
           >
-            <GoCopy size={20} />
+            <Tooltip id="go-copy" />
+            <GoCopy
+              data-tooltip-id="go-copy"
+              data-tooltip-content="Copy"
+              size={20}
+            />
           </Button>
 
           <Button
             isSelected={optionSelected === ShareOption.TWEET}
             onClick={selectTweet}
           >
-            <CiTwitter size={20} />
+            <Tooltip id="ci-twitter" />
+            <CiTwitter
+              data-tooltip-id="ci-twitter"
+              data-tooltip-content="Share on X"
+              size={20}
+            />
           </Button>
 
           <Button
             isSelected={optionSelected === ShareOption.LINKEDIN}
             onClick={selectLinkedIn}
           >
-            <CiLinkedin size={18} />
+            <Tooltip id="ci-linkedIn" />
+            <CiLinkedin
+              data-tooltip-id="ci-linkedIn"
+              data-tooltip-content="Share on LinkedIn"
+              size={18}
+            />
           </Button>
 
           <Button
             isSelected={optionSelected === ShareOption.DOWNLOAD}
             onClick={selectDownload}
           >
-            <GoDownload size={18} />
+            <Tooltip id="go-download" />
+            <GoDownload
+              data-tooltip-id="go-download"
+              data-tooltip-content="Downlaod Image"
+              size={18}
+            />
           </Button>
 
           <Button
             isSelected={optionSelected === ShareOption.COPY}
             onClick={selectCopy}
           >
-            <GoCopy size={18} />
+            <GoCopy
+              data-tooltip-id="go-copy"
+              data-tooltip-content="Copy"
+              size={18}
+            />
           </Button>
         </div>
         <button


### PR DESCRIPTION
## Issue(s) 

https://github.com/middlewarehq/unwrapped/issues/62

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteria are provided -->

- [x] Should Have Tootip on Copy Button
- [x] Should Have Tootip on Share on X Button
- [x] Should Have Tootip on Share on LinkedIn Button
- [x] Should Have Tootip on Download Button

## Proposed changes (including videos or screenshots)

The requirement of having a tooltip on each of the button can be easily fullfilled by using react-tooltip package(already present in the project). This Tooltip is aligned with the current design of the app, and is useful to communicate proper functionality of the feature.

[screen-capture (9).webm](https://github.com/user-attachments/assets/504a050d-97dc-41fe-969d-cab8d253702f)


<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->